### PR TITLE
Better asserts to check collect_interaction_data

### DIFF
--- a/labs/DRL.03.ModelBased.ipynb
+++ b/labs/DRL.03.ModelBased.ipynb
@@ -279,9 +279,13 @@
     "\n",
     "data_size = 1000\n",
     "data = collect_interaction_data(env, size=data_size)\n",
-    "assert len(data) == data_size\n",
-    "assert isinstance(data[0], Transition)\n",
-    "assert all([isinstance(field, torch.Tensor) for field in data[0]])\n",
+    "\n",
+    "# the code below will check that collect_interaction_data implementation is correct-ish\n",
+    "assert isinstance(data, list) and len(data) == data_size, \"return value should be a list of length data_size\"\n",
+    "assert isinstance(data[0], Transition), \"return value should be a list whose elements are Transition tuples\"\n",
+    "assert all([isinstance(field, torch.Tensor) and field.dtype == torch.float64 for field in data[0]]), \"Transition tuples should contain torch tensors whose types are float64\"\n",
+    "\n",
+    "# print the first transition\n",
     "print(\"Sample transition:\", data[0])"
    ]
   },


### PR DESCRIPTION
This PR gives much more useful feedback that `collect_interaction_data` is doing the right thing. I was happy with the raw assertion failures, but people who are not python experts will suffer to understand what the assertion is detecting. It also is more thorough: that the data is a list, and the the torch tensors are of compatible types (i accidentally wrote an implementation that used mixed types and the code later on in the tutorial was not happy)